### PR TITLE
Fix `repository.url`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "homepage": "http://github.com/Zertz/unicode-json",
   "repository": {
     "type": "git",
-    "url": "git://github.com/Zertz/-json.git"
+    "url": "git://github.com/Zertz/unicode-json.git"
   },
   "engines": {
     "node": ">=0.10"


### PR DESCRIPTION
Closes https://github.com/Zertz/unicode-json/issues/5.
