### PR TITLE
Add default location of UnicodeData.txt on RHEL

### DIFF
--- a/install.js
+++ b/install.js
@@ -28,6 +28,7 @@ var keys = [
 var systemfiles = [
   '/usr/share/unicode/UnicodeData.txt', // debian
   '/usr/share/unicode-data/UnicodeData.txt', // gentoo
+  '/usr/share/unicode/ucd/UnicodeData.txt', // redhat, unicode-ucd package
   process.env.NODE_UNICODETABLE_UNICODEDATA_TXT || 'UnicodeData.txt' // manually downloaded
 ]
 


### PR DESCRIPTION
The unicode-ucd package installs UnicodeData.txt in /usr/share/unicode/ucd. This applies to RedHat (RHEL), Fedora, CentOS, Amazon Linux and other derivatives.

See https://rpmfind.net/linux/RPM/fedora/devel/rawhide/armhfp/u/unicode-ucd-9.0.0-3.fc26.noarch.html